### PR TITLE
Fixed logo distortion & disadvantage of wide aspect-ratio logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@ width: 300px;
 .grid__item .archive__item-teaser {
     height: 151px;
     max-height: 151px;
-    max-width: 151px; 
 }
 .archive__item-teaser img {
     width: 100%; 
     height: 151px; 
+    object-fit: contain;
 }
 
 -->


### PR DESCRIPTION
- Fixed small logo distortion issue on main page
- Let logos use the whole width of the teaser text to adjust for wide aspect ratio logos (e.g. CADUS)

Distortions
![fix-scaling-BEFORE](https://user-images.githubusercontent.com/16517708/68078241-6589cd00-fdd2-11e9-902a-c0fb8d6f114b.png)
No distortions
![fix-scaling-AFTER](https://user-images.githubusercontent.com/16517708/68078243-6c184480-fdd2-11e9-8de2-971e11f61946.png)

Smaller size of logos with a wide aspect-ratio (+ distortions)
![fix-aspect-BEFORE](https://user-images.githubusercontent.com/16517708/68078245-70446200-fdd2-11e9-8caf-53a08ffc01a7.png)
Better use of space for logos with a wide aspect-ratio
![fix-aspect-AFTER](https://user-images.githubusercontent.com/16517708/68078246-72a6bc00-fdd2-11e9-8c9a-fab729f98f34.png)

